### PR TITLE
63 lit protocol 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.env

--- a/src/app/api/credentials/[credId]/route.ts
+++ b/src/app/api/credentials/[credId]/route.ts
@@ -1,57 +1,13 @@
 import axios from "axios";
 import { ethers } from "ethers";
 
+import { generateUUIDwithTimestamp } from "@/utils/uuid";
+
 import { fetchStats } from "../../route";
 import fetchTopLanguages from "../../route1";
 
-// {
-//   login: 'yashgo0018',
-//   id: 39233126,
-//   node_id: 'MDQ6VXNlcjM5MjMzMTI2',
-//   avatar_url: 'https://avatars.githubusercontent.com/u/39233126?v=4',
-//   gravatar_id: '',
-//   url: 'https://api.github.com/users/yashgo0018',
-//   html_url: 'https://github.com/yashgo0018',
-//   followers_url: 'https://api.github.com/users/yashgo0018/followers',
-//   following_url: 'https://api.github.com/users/yashgo0018/following{/other_user}',
-//   gists_url: 'https://api.github.com/users/yashgo0018/gists{/gist_id}',
-//   starred_url: 'https://api.github.com/users/yashgo0018/starred{/owner}{/repo}',
-//   subscriptions_url: 'https://api.github.com/users/yashgo0018/subscriptions',
-//   organizations_url: 'https://api.github.com/users/yashgo0018/orgs',
-//   repos_url: 'https://api.github.com/users/yashgo0018/repos',
-//   events_url: 'https://api.github.com/users/yashgo0018/events{/privacy}',
-//   received_events_url: 'https://api.github.com/users/yashgo0018/received_events',
-//   type: 'User',
-//   site_admin: false,
-//   name: 'Yash Goyal',
-//   company: null,
-//   blog: 'yashgoyal.dev',
-//   location: null,
-//   email: 'yashgo0018@gmail.com',
-//   hireable: true,
-//   bio: 'Blockchain Developer, Machine Learning Engineer.',
-//   twitter_username: null,
-//   public_repos: 61,
-//   public_gists: 6,
-//   followers: 27,
-//   following: 16,
-//   created_at: '2018-05-13T07:03:07Z',
-//   updated_at: '2023-11-02T12:40:37Z',
-//   private_gists: 1,
-//   total_private_repos: 11,
-//   owned_private_repos: 9,
-//   disk_usage: 192197,
-//   collaborators: 2,
-//   two_factor_authentication: false,
-//   plan: {
-//     name: 'pro',
-//     space: 976562499,
-//     collaborators: 0,
-//     private_repos: 9999
-//   }
-// }
-
 interface Claim {
+  id: string;
   platform: string;
   criteria: string;
   condition: string;
@@ -59,6 +15,7 @@ interface Claim {
 }
 
 interface Credential {
+  id: string;
   author: string;
   platform: string;
   description: string;
@@ -81,6 +38,7 @@ async function createCredential(userAddress: string, claims: Claim[]) {
   console.log(signer);
 
   const credential: Credential = {
+    id: generateUUIDwithTimestamp(),
     author: "Talentlayer Core Team",
     platform: "github.com",
     description:
@@ -103,6 +61,7 @@ async function createCredential(userAddress: string, claims: Claim[]) {
   const signature2 = await signer.signMessage(credentialHash2);
 
   return {
+    id: generateUUIDwithTimestamp(),
     issuer: await signer.getAddress(),
     signature1,
     signature2,
@@ -127,6 +86,7 @@ async function generateClaims(token: string) {
   const createdAtMonth = new Date(createdAt.getFullYear(), createdAt.getMonth());
 
   const accountCreationClaim = {
+    id: generateUUIDwithTimestamp(),
     platform: "github.com",
     criteria: "accountCreation",
     condition: "==",
@@ -137,6 +97,7 @@ async function generateClaims(token: string) {
 
   if (userData.followers > 0) {
     const followersClaim = {
+      id: generateUUIDwithTimestamp(),
       platform: "github.com",
       criteria: "followers",
       condition: ">=",
@@ -155,6 +116,7 @@ async function generateClaims(token: string) {
     for (const matrixPoint of matrixPoints) {
       if ((stats as any)[matrixPoint] > 0) {
         claims.push({
+          id: generateUUIDwithTimestamp(),
           platform: "github.com",
           criteria: matrixPoint,
           condition: "==",
@@ -172,6 +134,7 @@ async function generateClaims(token: string) {
 
   if (top5Languages.length != 0) {
     claims.push({
+      id: generateUUIDwithTimestamp(),
       platform: "github.com",
       criteria: "top5Languages",
       condition: "==",

--- a/src/app/credentials/[credId]/page.tsx
+++ b/src/app/credentials/[credId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { HomeIcon } from "@heroicons/react/24/solid";
-import { EvmContractConditions } from "@lit-protocol/types";
+import { AccessControlConditions } from "@lit-protocol/types";
 import { Card, Text } from "@radix-ui/themes";
 import axios from "axios";
 import Link from "next/link";
@@ -112,39 +112,23 @@ export default function CredentialPage() {
 
   console.log(initialProfile);
 
-  const accessControlConditions: EvmContractConditions = [
+  // This access control condition check if the user balance of the following contract (TalentLayerId) is >= 1
+  // Generated with : https://lit-share-modal-v3-playground.netlify.app/
+  const accessControlConditions: AccessControlConditions = [
     {
-      conditionType: "evmContract",
-      contractAddress: env.NEXT_PUBLIC_DID_ADDRESS,
-      functionName: "balanceOf",
-      functionParams: [":userAddress"],
-      functionAbi: {
-        type: "function",
-        stateMutability: "view",
-        outputs: [
-          {
-            type: "uint256",
-            name: "",
-            internalType: "uint256",
-          },
-        ],
-        name: "balanceOf",
-        inputs: [
-          {
-            type: "address",
-            name: "account",
-            internalType: "address",
-          },
-        ],
-      },
-      chain: env.NEXT_PUBLIC_CHAIN == "testnet" ? "mumbai" : "polygon",
-      returnValueTest: {
-        key: "",
-        comparator: ">",
-        value: "0",
-      },
-    },
-  ];
+      "conditionType": "evmBasic",
+      "contractAddress": env.NEXT_PUBLIC_DID_ADDRESS,
+      "standardContractType": "ERC20",
+      "chain": env.NEXT_PUBLIC_CHAIN == "testnet" ? "mumbai" : "polygon",
+      "method": "balanceOf",
+      "parameters": [
+          ":userAddress"
+      ],
+      "returnValueTest": {
+          "comparator": ">=",
+          "value": "1"
+      }
+  }];
 
   useEffect(() => {
     (async () => {
@@ -201,7 +185,7 @@ export default function CredentialPage() {
       id: generateUUIDwithTimestamp(),
       ...data,
       total: credential.credential.claims?.length || 0,
-      condition: accessControlConditions,
+      condition: JSON.stringify(accessControlConditions), // saved as json for easy storage in ipfs - no need to define a new type
     };
     profileData.credentials.push(newCredential);
     const cid = await postToIPFS(JSON.stringify(profileData));

--- a/src/app/credentials/[credId]/page.tsx
+++ b/src/app/credentials/[credId]/page.tsx
@@ -36,17 +36,16 @@ export default function CredentialPage() {
   const [transactionHash, setTransactionHash] = useState<string>();
   const { credId } = useParams<{ credId: string }>();
 
-  if (!Object.hasOwn(availableCreds, credId)) {
-    return <div>Credential Not Found</div>;
-  }
-
   useEffect(() => {
+    if (!Object.hasOwn(availableCreds, credId)) {
+      return;
+    }
     const params = new URLSearchParams();
     params.set("client_id", availableCreds[credId].clientId);
     params.set("scope", availableCreds[credId].scope);
     params.set("redirect_url", window.location.origin + window.location.pathname);
     setConnectionUrl(`${availableCreds[credId].authenticationUrl}?${params.toString()}`);
-  }, []);
+  }, [credId]);
 
   useEffect(() => {
     if (!code || !address) return;
@@ -67,7 +66,7 @@ export default function CredentialPage() {
         setLoading(false);
       }
     })();
-  }, [code, address]);
+  }, [code, address, credId]);
 
   const { data: client } = useWalletClient();
 
@@ -234,6 +233,10 @@ export default function CredentialPage() {
         <CreateTalentLayerId />
       </div>
     );
+  }
+
+  if (!Object.hasOwn(availableCreds, credId)) {
+    return <div>Credential Not Found</div>;
   }
 
   return (

--- a/src/app/credentials/[credId]/page.tsx
+++ b/src/app/credentials/[credId]/page.tsx
@@ -22,6 +22,7 @@ import StepsTabs from "@/components/steps-tabs";
 import { env } from "@/env.mjs";
 import { postToIPFS } from "@/utils/ipfs";
 import lit from "@/utils/lit-utils/lit";
+import { generateUUIDwithTimestamp } from "@/utils/uuid";
 
 export default function CredentialPage() {
   const [stepId, setStepId] = useState(1);
@@ -197,6 +198,7 @@ export default function CredentialPage() {
     const newCredential = structuredClone(credential);
     delete newCredential.credential.claims;
     newCredential.credential.claimsEncrypted = {
+      id: generateUUIDwithTimestamp(),
       ...data,
       total: credential.credential.claims?.length || 0,
       condition: accessControlConditions,

--- a/src/app/credentials/[credId]/page.tsx
+++ b/src/app/credentials/[credId]/page.tsx
@@ -116,19 +116,18 @@ export default function CredentialPage() {
   // Generated with : https://lit-share-modal-v3-playground.netlify.app/
   const accessControlConditions: AccessControlConditions = [
     {
-      "conditionType": "evmBasic",
-      "contractAddress": env.NEXT_PUBLIC_DID_ADDRESS,
-      "standardContractType": "ERC20",
-      "chain": env.NEXT_PUBLIC_CHAIN == "testnet" ? "mumbai" : "polygon",
-      "method": "balanceOf",
-      "parameters": [
-          ":userAddress"
-      ],
-      "returnValueTest": {
-          "comparator": ">=",
-          "value": "1"
-      }
-  }];
+      conditionType: "evmBasic",
+      contractAddress: env.NEXT_PUBLIC_DID_ADDRESS,
+      standardContractType: "ERC20",
+      chain: env.NEXT_PUBLIC_CHAIN == "testnet" ? "mumbai" : "polygon",
+      method: "balanceOf",
+      parameters: [":userAddress"],
+      returnValueTest: {
+        comparator: ">=",
+        value: "1",
+      },
+    },
+  ];
 
   useEffect(() => {
     (async () => {
@@ -179,8 +178,12 @@ export default function CredentialPage() {
         c.credential.author !== credential.credential.author ||
         c.credential.platform !== credential.credential.platform,
     );
-    const newCredential = structuredClone(credential);
+    // Ensure id uniqueness
+    const newCredential = {...credential};
+    newCredential.id = generateUUIDwithTimestamp();
+    newCredential.credential.id = generateUUIDwithTimestamp();
     delete newCredential.credential.claims;
+
     newCredential.credential.claimsEncrypted = {
       id: generateUUIDwithTimestamp(),
       ...data,
@@ -205,7 +208,21 @@ export default function CredentialPage() {
         c.credential.author !== credential.credential.author ||
         c.credential.platform !== credential.credential.platform,
     );
-    profileData.credentials.push(credential);
+
+    // Ensure id uniqueness
+    const newCredential = {...credential};
+    newCredential.id = generateUUIDwithTimestamp();
+    newCredential.credential.id = generateUUIDwithTimestamp();
+    delete newCredential.credential.claimsEncrypted;
+
+    // Stringify complex values
+    newCredential.credential.claims?.map((claim) => {
+      claim.id = generateUUIDwithTimestamp();
+      if (typeof claim.value !== "string") {
+        claim.value = JSON.stringify(claim.value);
+      }
+    });
+    profileData.credentials.push(newCredential);
     const cid = await postToIPFS(JSON.stringify(profileData));
     setNewCid(cid);
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { availableCreds } from "@/availableCred";
 import { MagnifyingGlassIcon } from "@heroicons/react/24/solid";
 import { Box, Grid, TextFieldInput, TextFieldRoot, TextFieldSlot } from "@radix-ui/themes";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+
+import { availableCreds } from "@/availableCred";
 
 export default function Home() {
   const router = useRouter();
@@ -11,7 +12,7 @@ export default function Home() {
 
   return (
     <div>
-      <div className="text-center text-3xl mt-10">Get Credentials</div>
+      <div className="mt-10 text-center text-3xl">Get Credentials</div>
       <div className="mt-10">
         <TextFieldRoot>
           <TextFieldSlot>
@@ -32,10 +33,10 @@ export default function Home() {
             return availableCreds[credId].name.toLowerCase().includes(search.toLowerCase());
           })
           .map((credId) => (
-            <Box height="9">
+            <Box height="9" key={credId}>
               <div
                 onClick={() => router.push(`/credentials/${credId}`, { scroll: false })}
-                className="rounded-lg p-5 border-2 border-black"
+                className="rounded-lg border-2 border-black p-5"
               >
                 {availableCreds[credId].name} Credential
               </div>

--- a/src/interfaces/Credential.d.ts
+++ b/src/interfaces/Credential.d.ts
@@ -1,8 +1,10 @@
 interface Credential {
+  id: string;
   issuer: string;
   signature1: string;
   signature2: string;
   credential: {
+    id: string;
     author: string;
     platform: string;
     description: string;
@@ -10,12 +12,14 @@ interface Credential {
     expiryTime: string;
     userAddress: string;
     claims?: {
+      id: string;
       platform: string;
       criteria: string;
       condition: string;
       value: any;
     }[];
     claimsEncrypted?: {
+      id: string;
       total: number;
       ciphertext: string;
       dataToEncryptHash: string;

--- a/src/utils/lit-utils/lit.ts
+++ b/src/utils/lit-utils/lit.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import * as LitJsSdk from "@lit-protocol/lit-node-client";
-import { EvmContractConditions } from "@lit-protocol/types";
+import { AccessControlConditions } from "@lit-protocol/types";
 import { GetWalletClientResult } from "@wagmi/core";
 
 import { signAndSaveAuthMessage } from "./signature";
@@ -23,9 +23,10 @@ class Lit {
     await this.litNodeClient.connect();
   }
 
+  // We use AccessControlConditions, not to be confused with EVMContractConditions
   async encrypt(
     client: GetWalletClientResult,
-    evmContractConditions: EvmContractConditions,
+    accessControlConditions: AccessControlConditions,
     message: string,
   ) {
     if (!this.litNodeClient.connectedNodes) {
@@ -38,8 +39,7 @@ class Lit {
     });
     const { ciphertext, dataToEncryptHash } = await LitJsSdk.encryptString(
       {
-        evmContractConditions,
-        // accessControlConditions,
+        accessControlConditions,
         authSig,
         chain: this.chain,
         dataToEncrypt: message,

--- a/src/utils/uuid.ts
+++ b/src/utils/uuid.ts
@@ -1,0 +1,9 @@
+export const generateUUIDwithTimestamp = () => {
+    const timestamp = Date.now().toString();
+    const uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+        const r = Math.random() * 16 | 0,
+            v = c === 'x' ? r : (r & 0x3 | 0x8);
+        return v.toString(16);
+    });
+    return `${uuid}-${timestamp}`;
+}


### PR DESCRIPTION
- [x] Create a credential format.
- [x] Create an express function which takes a user's off-chain user profile and gets all his available history, then formats the data in the predefined credential format. For the first example, we will use Github as the example off-chain user profile.
- [x] Create an interface where users will be able to login and choose the platform from where they want to fetch their web2 history, initially, it would just be Github, but the individual platforms will be able to add more. For the first example, we will use TalentLayer StarterKit boilerplate as the example interface.
- [x] Create a toggle switch, where users will be able to encrypt the credential data using the lit access control, where the access control condition will be checking if the visitor is the holder of a specific on-chain credential. For the first example, we will use TalentLayer ID as the example credential.
- [x] Add the credentials on the user’s profile page, and if the credential is encrypted and user doesn’t hold the specified on-chain credential, then show a blur.